### PR TITLE
Build a secure professional studio for Suno creators

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
 # Control Panel Secret
 # Used to protect the /control page
 CONTROL_SECRET=your_secret_here
+BACKEND_URL=http://localhost:5555
+REDIS_URL=redis://localhost:6379/0
+SESSION_FERNET_KEY=
+SUNO_SESSION_ID_PATH=.data/suno_session.txt
+FLASK_DEBUG=false

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,8 +7,8 @@ Purpose
 
 What to check first (actionable, in order)
 
-1. Inspect `app.py` and `script.js` to learn runtime behavior (Dev server: Flask, debug=True, port=5555). Frontend expects `API_URL = 'http://localhost:5555/api'`.
-2. Locate the Suno session path constant (`SESSION_ID_PATH`) used by `app.py` and `master_sync.py`. By default it uses `/Users/blackmamba/suno_downloader/suno_session.txt`—this must exist or be provided by the user/Tampermonkey script.
+1. Inspect `app.py` and `script.js` to learn runtime behavior (Dev server: Flask, debug controlled by `FLASK_DEBUG`, port 5555). Frontend expects `API_URL = 'http://localhost:5555/api'`.
+2. Locate the Suno session path constant (`SESSION_ID_PATH`) used by `app.py` and `master_sync.py`. By default it uses `.data/suno_session.txt` under `SUNOPO_BASE_DIR`; it must exist or be provided by the user/Tampermonkey script.
 3. Check for system deps: `pydub` requires ffmpeg installed on macOS (`brew install ffmpeg`).
 4. Confirm missing dependency manifest (`requirements.txt` or `pyproject.toml`). If absent, ask whether to add one and which Python version to target.
 5. Review `reports/` and `exports/` locations. Paths are currently absolute (macOS /Users/blackmamba/...), so update constants when running in a different environment.
@@ -48,7 +48,7 @@ Session handling & automation 🔐
 - Suno client usage pattern:
   - Prefer `SunoClient.iter_songs()` for streaming large libraries (used in `master_sync.py`) to avoid loading all pages into memory at once. Unit tests show how to monkeypatch `suno.Suno` for offline testing.
 
-- Note on absolute paths: by default `SESSION_ID_PATH` points to `/Users/blackmamba/suno_downloader/suno_session.txt`—update `SUNO_SESSION_ID_PATH` or `SUNOPO_BASE_DIR` in `config.py` or via env vars when running on another machine.
+- Session path: by default `SESSION_ID_PATH` points to `.data/suno_session.txt` under `SUNOPO_BASE_DIR`; override `SUNO_SESSION_ID_PATH` when needed.
 
 Key workflows & scripts (what they do)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ BlackMamba is a Suno-like audio generation interface with a minimal black theme.
 
 - **Display Page** (`/display`): Public Spanish interface with audio generation, progress tracking, playback, download, and share functionality
 - **Control Panel** (`/control`): Private English administrative interface protected by CONTROL_SECRET
-- **Mock API**: Simulated audio generation with random delays (1.5-3 seconds)
+- **Suno integration**: Real audio generation through the Flask backend
 - **Black Minimal Theme**: Built with TailwindCSS for a sleek, modern look
 
 ## Prerequisites
@@ -79,7 +79,7 @@ cp .env.example .env.local
 
 4. Update the `.env.local` file with your secret:
 ```env
-NEXT_PUBLIC_CONTROL_SECRET=your-secret-here
+CONTROL_SECRET=your-secret-here
 ```
 
 ### Development
@@ -119,14 +119,12 @@ Protected admin panel requiring a secret to access:
 - View recent activity
 
 **Language**: English
-**Default Secret**: `blackmamba2024` (change in `.env.local`)
-
-> **⚠️ Security Note**: The current implementation uses client-side authentication for simplicity. In a production environment, implement proper server-side authentication with secure session management.
+Authentication is validated server-side and stored in a signed, HttpOnly cookie.
 
 ## API Routes
 
 ### POST `/api/generate`
-Generates a mock audio file with random delay.
+Proxies audio generation to the Flask/Suno backend.
 
 **Response**:
 ```json
@@ -146,14 +144,12 @@ The app uses a black minimal theme. To customize:
 - Modify Tailwind classes in component files
 
 ### Audio Generation
-The `/api/generate` endpoint currently returns a sample file. To integrate real audio generation:
-1. Update `app/api/generate/route.ts`
-2. Add your audio generation logic
-3. Return the generated audio URL
+The `/api/generate` endpoint proxies requests to the Flask backend configured by
+`BACKEND_URL`.
 
 ### Secret Protection
 To change the control panel secret:
-1. Update `NEXT_PUBLIC_CONTROL_SECRET` in `.env.local`
+1. Update `CONTROL_SECRET` in `.env.local`
 2. Restart the development server
 
 ## Project Structure
@@ -182,7 +178,8 @@ Sunopo/
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `NEXT_PUBLIC_CONTROL_SECRET` | Secret to access control panel | `blackmamba2024` |
+| `CONTROL_SECRET` | Server-side secret to access control panel | Required |
+| `BACKEND_URL` | Flask backend used for generation | `http://localhost:5555` |
 | `NEXT_PUBLIC_APP_NAME` | Application name | `BlackMamba` |
 
 ## License

--- a/app.py
+++ b/app.py
@@ -1,18 +1,37 @@
-import os
-import requests
 import io
-from flask import Flask, jsonify, request, send_from_directory, send_file
+import logging
+import re
+
+import requests
+from flask import Flask, jsonify, request, send_from_directory
 from flask_cors import CORS
-from suno import Suno
 from pydub import AudioSegment
-import json
+from redis.exceptions import RedisError
+from suno import Suno
 
 from suno_client import SunoClient
 
 app = Flask(__name__)
 CORS(app)
 
-from config import EXPORTS_DIR, SESSION_ID_PATH, ensure_dirs, read_session_id
+from config import (
+    EXPORTS_DIR,
+    FLASK_DEBUG,
+    FLASK_HOST,
+    FLASK_PORT,
+    REDIS_URL,
+    SESSION_FERNET_KEY,
+    SESSION_ID_PATH,
+    SESSION_TTL_SECONDS,
+    ensure_dirs,
+    read_session_id,
+)
+
+logger = logging.getLogger(__name__)
+SAFE_SONG_ID = re.compile(r"^[A-Za-z0-9_-]+$")
+MAX_PROMPT_LENGTH = 5000
+MAX_TITLE_LENGTH = 200
+MAX_TAGS_LENGTH = 1000
 
 # Ensure directories exist on startup
 ensure_dirs()
@@ -27,7 +46,7 @@ try:
         redis_url=REDIS_URL, ttl=SESSION_TTL_SECONDS, fernet_key=SESSION_FERNET_KEY
     )
 except Exception as e:
-    print(f"Warning: Session store not configured: {e}")
+    logger.warning("Session store not configured: %s", type(e).__name__)
 
 
 def get_session_id():
@@ -44,8 +63,9 @@ def get_session_id():
 
         # 2. Authorization header: Bearer <token>
         auth = request.headers.get("Authorization")
-        if auth and auth.lower().startswith("bearer "):
-            token = auth.split(None, 1)[1].strip()
+        if auth:
+            scheme, separator, credentials = auth.partition(" ")
+            token = credentials.strip() if separator and scheme.lower() == "bearer" else ""
             if token and session_store:
                 cookie = session_store.get_session(token)
                 if cookie:
@@ -65,20 +85,20 @@ def get_session_id():
             if cookie:
                 return cookie
 
-    except Exception:
+    except (RuntimeError, OSError, RedisError):
         # No request context or redis not available
         pass
 
-    try:
-        return read_session_id()
-    except Exception as e:
-        print(f"Error leyendo session ID: {e}")
-        return None
+    return read_session_id()
+
+
+def is_valid_song_id(song_id):
+    return bool(SAFE_SONG_ID.fullmatch(song_id))
 
 
 @app.route("/api/update_session", methods=["POST"])
 def update_session():
-    data = request.json
+    data = request.get_json(silent=True) or {}
     session_id = data.get("session_id")
     if not session_id:
         return jsonify({"error": "No session_id provided"}), 400
@@ -87,8 +107,9 @@ def update_session():
         with open(SESSION_ID_PATH, "w") as f:
             f.write(session_id)
         return jsonify({"success": True, "message": "Session ID updated successfully"})
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
+    except OSError:
+        logger.exception("Unable to update session file")
+        return jsonify({"error": "Unable to update session"}), 500
 
 
 @app.route("/api/session", methods=["POST"])
@@ -113,8 +134,9 @@ def create_session():
             max_age=SESSION_TTL_SECONDS,
         )
         return resp
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
+    except (RuntimeError, ValueError):
+        logger.exception("Unable to create session")
+        return jsonify({"error": "Unable to create session"}), 500
 
 
 @app.route("/api/session/validate", methods=["GET"])
@@ -156,12 +178,18 @@ def generate_audio():
 
     data = request.json or {}
     prompt = data.get("prompt")
-    if not prompt:
+    if not isinstance(prompt, str) or not prompt.strip():
         return jsonify({"error": "No prompt provided"}), 400
+    if len(prompt) > MAX_PROMPT_LENGTH:
+        return jsonify({"error": "Prompt is too long"}), 400
 
     is_custom = data.get("is_custom", False)
     tags = data.get("tags", "")
     title = data.get("title", "")
+    if not isinstance(tags, str) or len(tags) > MAX_TAGS_LENGTH:
+        return jsonify({"error": "Tags are invalid or too long"}), 400
+    if not isinstance(title, str) or len(title) > MAX_TITLE_LENGTH:
+        return jsonify({"error": "Title is invalid or too long"}), 400
     make_instrumental = data.get("make_instrumental", False)
     wait_audio = data.get("wait_audio", True)
 
@@ -189,16 +217,18 @@ def generate_audio():
                     "created_at": clip.created_at,
                     "status": clip.status,
                     "metadata": {
-                        "tags": clip.metadata.tags,
-                        "prompt": clip.metadata.prompt,
+                        "tags": getattr(getattr(clip, "metadata", None), "tags", ""),
+                        "prompt": getattr(
+                            getattr(clip, "metadata", None), "prompt", ""
+                        ),
                     },
                 }
             )
 
         return jsonify({"success": True, "clips": result})
-    except Exception as e:
-        print(f"Generation error: {e}")
-        return jsonify({"error": str(e)}), 500
+    except Exception:
+        logger.exception("Suno generation failed")
+        return jsonify({"error": "Audio generation failed"}), 502
 
 
 @app.route("/api/songs", methods=["GET"])
@@ -287,38 +317,16 @@ def get_songs():
                 }
             )
 
-    except Exception as e:
-        print(f"Suno API Error: {e}")
-        # Fallback to mock data for demonstration if API fails
-        mock_songs = [
-            {
-                "id": "mock_1",
-                "title": "Soberanía Digital (Demo)",
-                "artist": "Iyari Gomez",
-                "author": "Iyari Cancino Gomez",
-                "image_url": "https://images.unsplash.com/photo-1614613535308-eb5fbd3d2c17?w=400",
-                "audio_url": "#",
-                "status": "complete",
-                "created_at": "2024-03-20",
-                "lyrics": "[Verse 1]\nEn el código está mi voz\nSoberano en el servidor\nSin cadenas, sin temor\nIyari Gomez es el motor...",
-            },
-            {
-                "id": "mock_2",
-                "title": "Fuerza Alpha (Demo)",
-                "artist": "Iyari Gomez",
-                "author": "Iyari Cancino Gomez",
-                "image_url": "https://images.unsplash.com/photo-1514525253361-bee8718a74a1?w=400",
-                "audio_url": "#",
-                "status": "complete",
-                "created_at": "2024-03-20",
-                "lyrics": "[Chorus]\nFuerza Alpha, luz celestial\nMovimiento universal\nCancino Gomez lo hará real\nEn un mundo digital...",
-            },
-        ]
-        return jsonify(mock_songs)
+    except Exception:
+        logger.exception("Suno API request failed")
+        return jsonify({"error": "Unable to load songs"}), 502
 
 
 @app.route("/api/generate_wav/<song_id>", methods=["POST"])
 def generate_wav(song_id):
+    if not is_valid_song_id(song_id):
+        return jsonify({"error": "Invalid song ID"}), 400
+
     session_id = get_session_id()
     if not session_id:
         return jsonify({"error": "Session ID not found"}), 400
@@ -333,13 +341,14 @@ def generate_wav(song_id):
             return jsonify({"error": "Song or Audio URL not found"}), 404
 
         # Descargar el MP3
-        response = requests.get(song.audio_url)
+        response = requests.get(song.audio_url, timeout=(5, 30))
+        response.raise_for_status()
         audio_data = io.BytesIO(response.content)
 
         # Convertir a WAV de alta calidad (44.1kHz, 16-bit)
         audio = AudioSegment.from_file(audio_data, format="mp3")
         wav_filename = f"{song_id}.wav"
-        wav_path = os.path.join(EXPORTS_DIR, wav_filename)
+        wav_path = EXPORTS_DIR / wav_filename
 
         audio.export(wav_path, format="wav", parameters=["-ar", "44100", "-ac", "2"])
 
@@ -351,16 +360,24 @@ def generate_wav(song_id):
             }
         )
 
-    except Exception as e:
-        print(f"Error generando WAV: {e}")
-        return jsonify({"error": str(e)}), 500
+    except requests.Timeout:
+        return jsonify({"error": "Audio download timed out"}), 504
+    except requests.RequestException:
+        logger.exception("Audio download failed")
+        return jsonify({"error": "Audio download failed"}), 502
+    except Exception:
+        logger.exception("WAV generation failed")
+        return jsonify({"error": "WAV generation failed"}), 500
 
 
 @app.route("/api/download/<song_id>", methods=["GET"])
 def download_wav(song_id):
-    wav_path = os.path.join(EXPORTS_DIR, f"{song_id}.wav")
-    if os.path.exists(wav_path):
-        return send_file(wav_path, as_attachment=True)
+    if not is_valid_song_id(song_id):
+        return jsonify({"error": "Invalid song ID"}), 400
+
+    wav_path = EXPORTS_DIR / f"{song_id}.wav"
+    if wav_path.is_file():
+        return send_from_directory(EXPORTS_DIR, wav_path.name, as_attachment=True)
     return jsonify({"error": "File not found"}), 404
 
 
@@ -379,7 +396,8 @@ def analyze_track(song_id):
             prompt = song.prompt if song else "Música electrónica futurista."
             title = song.title if song else "Untitled"
             lyrics = getattr(song, "lyrics", "") if song else ""
-        except:
+        except Exception:
+            logger.exception("Track analysis failed")
             prompt = "Música electrónica futurista."
             title = "Untitled"
             lyrics = ""
@@ -423,4 +441,4 @@ def static_proxy(path):
 
 
 if __name__ == "__main__":
-    app.run(debug=True, port=5555)
+    app.run(debug=FLASK_DEBUG, host=FLASK_HOST, port=FLASK_PORT)

--- a/app/api/control/auth.ts
+++ b/app/api/control/auth.ts
@@ -1,0 +1,26 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { NextRequest } from 'next/server';
+
+export const CONTROL_COOKIE_NAME = 'SUNOPO_CONTROL_AUTH';
+
+export function getControlSecret(): string | null {
+  return process.env.CONTROL_SECRET || null;
+}
+
+export function createControlToken(secret: string): string {
+  return createHmac('sha256', secret).update('sunopo-control').digest('hex');
+}
+
+export function isControlAuthenticated(request: NextRequest): boolean {
+  const secret = getControlSecret();
+  const supplied = request.cookies.get(CONTROL_COOKIE_NAME)?.value;
+  if (!secret || !supplied) return false;
+
+  const expected = createControlToken(secret);
+  const suppliedBuffer = Buffer.from(supplied);
+  const expectedBuffer = Buffer.from(expected);
+  return (
+    suppliedBuffer.length === expectedBuffer.length &&
+    timingSafeEqual(suppliedBuffer, expectedBuffer)
+  );
+}

--- a/app/api/control/verify/route.ts
+++ b/app/api/control/verify/route.ts
@@ -1,33 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createHmac, timingSafeEqual } from "node:crypto";
-
-const COOKIE_NAME = "SUNOPO_CONTROL_AUTH";
-
-function getControlSecret(): string | null {
-  return process.env.CONTROL_SECRET || null;
-}
-
-function createToken(secret: string): string {
-  return createHmac("sha256", secret).update("sunopo-control").digest("hex");
-}
-
-function hasValidToken(request: NextRequest, secret: string): boolean {
-  const supplied = request.cookies.get(COOKIE_NAME)?.value;
-  if (!supplied) return false;
-
-  const expected = createToken(secret);
-  const suppliedBuffer = Buffer.from(supplied);
-  const expectedBuffer = Buffer.from(expected);
-  return (
-    suppliedBuffer.length === expectedBuffer.length &&
-    timingSafeEqual(suppliedBuffer, expectedBuffer)
-  );
-}
+import {
+  CONTROL_COOKIE_NAME,
+  createControlToken,
+  getControlSecret,
+  isControlAuthenticated,
+} from "../auth";
 
 export async function GET(request: NextRequest) {
   const controlSecret = getControlSecret();
   return NextResponse.json({
-    authenticated: Boolean(controlSecret && hasValidToken(request, controlSecret)),
+    authenticated: Boolean(controlSecret && isControlAuthenticated(request)),
   });
 }
 
@@ -44,7 +26,7 @@ export async function POST(request: NextRequest) {
 
     if (secret === controlSecret) {
       const response = NextResponse.json({ success: true });
-      response.cookies.set(COOKIE_NAME, createToken(controlSecret), {
+      response.cookies.set(CONTROL_COOKIE_NAME, createControlToken(controlSecret), {
         httpOnly: true,
         sameSite: "strict",
         secure: process.env.NODE_ENV === "production",
@@ -69,7 +51,7 @@ export async function POST(request: NextRequest) {
 
 export async function DELETE() {
   const response = NextResponse.json({ success: true });
-  response.cookies.set(COOKIE_NAME, "", {
+  response.cookies.set(CONTROL_COOKIE_NAME, "", {
     httpOnly: true,
     sameSite: "strict",
     secure: process.env.NODE_ENV === "production",

--- a/app/api/control/verify/route.ts
+++ b/app/api/control/verify/route.ts
@@ -1,12 +1,57 @@
 import { NextRequest, NextResponse } from "next/server";
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const COOKIE_NAME = "SUNOPO_CONTROL_AUTH";
+
+function getControlSecret(): string | null {
+  return process.env.CONTROL_SECRET || null;
+}
+
+function createToken(secret: string): string {
+  return createHmac("sha256", secret).update("sunopo-control").digest("hex");
+}
+
+function hasValidToken(request: NextRequest, secret: string): boolean {
+  const supplied = request.cookies.get(COOKIE_NAME)?.value;
+  if (!supplied) return false;
+
+  const expected = createToken(secret);
+  const suppliedBuffer = Buffer.from(supplied);
+  const expectedBuffer = Buffer.from(expected);
+  return (
+    suppliedBuffer.length === expectedBuffer.length &&
+    timingSafeEqual(suppliedBuffer, expectedBuffer)
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const controlSecret = getControlSecret();
+  return NextResponse.json({
+    authenticated: Boolean(controlSecret && hasValidToken(request, controlSecret)),
+  });
+}
 
 export async function POST(request: NextRequest) {
   try {
     const { secret } = await request.json();
-    const controlSecret = process.env.CONTROL_SECRET || "default_secret";
+    const controlSecret = getControlSecret();
+    if (!controlSecret) {
+      return NextResponse.json(
+        { success: false, message: "Control panel is not configured" },
+        { status: 503 }
+      );
+    }
 
     if (secret === controlSecret) {
-      return NextResponse.json({ success: true });
+      const response = NextResponse.json({ success: true });
+      response.cookies.set(COOKIE_NAME, createToken(controlSecret), {
+        httpOnly: true,
+        sameSite: "strict",
+        secure: process.env.NODE_ENV === "production",
+        path: "/",
+        maxAge: 60 * 60 * 8,
+      });
+      return response;
     } else {
       return NextResponse.json(
         { success: false, message: "Invalid secret" },
@@ -20,4 +65,16 @@ export async function POST(request: NextRequest) {
       { status: 400 }
     );
   }
+}
+
+export async function DELETE() {
+  const response = NextResponse.json({ success: true });
+  response.cookies.set(COOKIE_NAME, "", {
+    httpOnly: true,
+    sameSite: "strict",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 0,
+  });
+  return response;
 }

--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from 'next/server';
 
 export async function POST(request: Request) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 300_000);
+
   try {
     const body = await request.json();
 
@@ -10,27 +13,47 @@ export async function POST(request: Request) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        // In a real scenario, we might want to pass through headers like Authorization or Cookies
-        // but for now, the Flask backend handles session from its own config/files if not provided.
+        ...(request.headers.get('authorization')
+          ? { Authorization: request.headers.get('authorization')! }
+          : {}),
+        ...(request.headers.get('cookie')
+          ? { Cookie: request.headers.get('cookie')! }
+          : {}),
+        ...(request.headers.get('x-session-token')
+          ? { 'X-Session-Token': request.headers.get('x-session-token')! }
+          : {}),
       },
       body: JSON.stringify(body),
+      signal: controller.signal,
     });
 
+    const contentType = response.headers.get('content-type') || '';
+    const responseData = contentType.includes('application/json')
+      ? await response.json()
+      : null;
+
     if (!response.ok) {
-      const errorData = await response.json();
       return NextResponse.json(
-        { error: errorData.error || 'Error from generation backend' },
+        { error: responseData?.error || 'Error from generation backend' },
         { status: response.status }
       );
     }
 
-    const data = await response.json();
-    return NextResponse.json(data);
+    if (!responseData) {
+      return NextResponse.json(
+        { error: 'Invalid response from generation backend' },
+        { status: 502 }
+      );
+    }
+    return NextResponse.json(responseData);
   } catch (error) {
-    console.error('Proxy error:', error);
+    const isTimeout = error instanceof Error && error.name === 'AbortError';
+    console.error('Proxy error:', error instanceof Error ? error.message : 'Unknown error');
     return NextResponse.json(
-      { error: 'Internal server error in API proxy' },
-      { status: 500 }
+      { error: isTimeout ? 'Generation backend timed out' : 'Internal server error in API proxy' },
+      { status: isTimeout ? 504 : 500 }
     );
+  } finally {
+    clearTimeout(timeout);
   }
 }

--- a/app/api/songs/route.ts
+++ b/app/api/songs/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { isControlAuthenticated } from '../control/auth';
+
+export async function GET(request: NextRequest) {
+  if (!isControlAuthenticated(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 30_000);
+
+  try {
+    const backendUrl = process.env.BACKEND_URL || 'http://localhost:5555';
+    const search = request.nextUrl.search;
+    const response = await fetch(`${backendUrl}/api/songs${search}`, {
+      headers: {
+        ...(request.headers.get('authorization')
+          ? { Authorization: request.headers.get('authorization')! }
+          : {}),
+        ...(request.headers.get('cookie')
+          ? { Cookie: request.headers.get('cookie')! }
+          : {}),
+        ...(request.headers.get('x-session-token')
+          ? { 'X-Session-Token': request.headers.get('x-session-token')! }
+          : {}),
+      },
+      cache: 'no-store',
+      signal: controller.signal,
+    });
+
+    const contentType = response.headers.get('content-type') || '';
+    const data = contentType.includes('application/json') ? await response.json() : null;
+
+    if (!response.ok || !data) {
+      return NextResponse.json(
+        { error: data?.error || 'Unable to load the Suno catalog' },
+        { status: response.ok ? 502 : response.status }
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    const isTimeout = error instanceof Error && error.name === 'AbortError';
+    return NextResponse.json(
+      { error: isTimeout ? 'Suno catalog request timed out' : 'Catalog service unavailable' },
+      { status: isTimeout ? 504 : 502 }
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/app/control/page.tsx
+++ b/app/control/page.tsx
@@ -1,41 +1,60 @@
 'use client';
 
-import { useState } from 'react';
-
-// Helper function to check initial auth state
-const getInitialAuthState = () => {
-  if (typeof window !== 'undefined') {
-    return sessionStorage.getItem('control_auth') === 'true';
-  }
-  return false;
-};
+import { useEffect, useState } from 'react';
 
 export default function ControlPage() {
-  const [isAuthenticated, setIsAuthenticated] = useState(getInitialAuthState);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isCheckingAuth, setIsCheckingAuth] = useState(true);
   const [secretInput, setSecretInput] = useState('');
   const [error, setError] = useState('');
 
-  const handleLogin = (e: React.FormEvent) => {
+  useEffect(() => {
+    fetch('/api/control/verify')
+      .then((response) => response.json())
+      .then((data) => setIsAuthenticated(data.authenticated === true))
+      .catch(() => setIsAuthenticated(false))
+      .finally(() => setIsCheckingAuth(false));
+  }, []);
+
+  const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
-    // NOTE: In production, use server-side authentication
-    // This is a simple client-side demo for illustration purposes only
-    const secret = process.env.NEXT_PUBLIC_CONTROL_SECRET || 'blackmamba2024';
-    
-    if (secretInput === secret) {
-      setIsAuthenticated(true);
-      sessionStorage.setItem('control_auth', 'true');
-      setError('');
-    } else {
-      setError('Invalid secret. Please try again.');
+    setError('');
+    try {
+      const response = await fetch('/api/control/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ secret: secretInput }),
+      });
+
+      if (response.ok) {
+        setIsAuthenticated(true);
+        setSecretInput('');
+        return;
+      }
+      setError(
+        response.status === 503
+          ? 'Control panel is not configured.'
+          : 'Invalid secret. Please try again.'
+      );
+    } catch {
+      setError('Unable to contact the authentication service.');
+    } finally {
       setSecretInput('');
     }
   };
 
-  const handleLogout = () => {
-    setIsAuthenticated(false);
-    sessionStorage.removeItem('control_auth');
-    setSecretInput('');
+  const handleLogout = async () => {
+    try {
+      await fetch('/api/control/verify', { method: 'DELETE' });
+    } finally {
+      setIsAuthenticated(false);
+      setSecretInput('');
+    }
   };
+
+  if (isCheckingAuth) {
+    return <div className="min-h-screen bg-black" aria-busy="true" />;
+  }
 
   if (!isAuthenticated) {
     return (

--- a/app/control/page.tsx
+++ b/app/control/page.tsx
@@ -1,12 +1,65 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+
+interface Song {
+  id: string;
+  title?: string;
+  artist?: string;
+  author?: string;
+  image_url?: string;
+  audio_url?: string;
+  created_at?: string;
+  status?: string;
+  prompt?: string;
+  lyrics?: string;
+}
+
+type CatalogFilter = 'all' | 'ready' | 'processing' | 'lyrics';
+
+const filters: Array<{ value: CatalogFilter; label: string }> = [
+  { value: 'all', label: 'Todo' },
+  { value: 'ready', label: 'Listo' },
+  { value: 'processing', label: 'Procesando' },
+  { value: 'lyrics', label: 'Con letra' },
+];
+
+const pendingStatuses = new Set(['queued', 'submitted', 'processing']);
+
+function isReady(song: Song) {
+  return Boolean(song.audio_url) && !pendingStatuses.has(song.status?.toLowerCase() || '');
+}
+
+function metadataScore(song: Song) {
+  const fields = [song.title, song.artist, song.prompt, song.lyrics, song.audio_url];
+  return Math.round((fields.filter(Boolean).length / fields.length) * 100);
+}
+
+function formatDate(value?: string) {
+  if (!value) return 'Sin fecha';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime())
+    ? value
+    : new Intl.DateTimeFormat('es', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+      }).format(date);
+}
 
 export default function ControlPage() {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isCheckingAuth, setIsCheckingAuth] = useState(true);
   const [secretInput, setSecretInput] = useState('');
-  const [error, setError] = useState('');
+  const [authError, setAuthError] = useState('');
+  const [songs, setSongs] = useState<Song[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [catalogError, setCatalogError] = useState('');
+  const [query, setQuery] = useState('');
+  const [filter, setFilter] = useState<CatalogFilter>('all');
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     fetch('/api/control/verify')
@@ -16,9 +69,80 @@ export default function ControlPage() {
       .finally(() => setIsCheckingAuth(false));
   }, []);
 
-  const handleLogin = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError('');
+  useEffect(() => {
+    if (!isAuthenticated) return;
+
+    const controller = new AbortController();
+    setIsLoading(true);
+    setCatalogError('');
+
+    const loadCatalog = async () => {
+      const collected: Song[] = [];
+      let page = 1;
+
+      while (page <= 10) {
+        const response = await fetch(`/api/songs?per_page=100&page=${page}`, {
+          signal: controller.signal,
+        });
+        const data = await response.json();
+        if (response.status === 401) {
+          setIsAuthenticated(false);
+          throw new Error('La sesion del estudio expiro');
+        }
+        if (!response.ok) {
+          throw new Error(data.error || 'No se pudo cargar el catalogo');
+        }
+        const items: Song[] = Array.isArray(data) ? data : data.items || [];
+        collected.push(...items);
+        if (!data.has_more || !data.next_page) break;
+        page = data.next_page;
+      }
+
+      return collected;
+    };
+
+    loadCatalog()
+      .then((items) => {
+        setSongs(items);
+        setSelectedId((current) => current || items[0]?.id || null);
+      })
+      .catch((error: unknown) => {
+        if (error instanceof Error && error.name !== 'AbortError') {
+          setCatalogError(error.message);
+        }
+      })
+      .finally(() => setIsLoading(false));
+
+    return () => controller.abort();
+  }, [isAuthenticated]);
+
+  const filteredSongs = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    return songs.filter((song) => {
+      const matchesQuery =
+        !normalizedQuery ||
+        [song.title, song.artist, song.prompt]
+          .filter(Boolean)
+          .some((value) => value?.toLowerCase().includes(normalizedQuery));
+      const matchesFilter =
+        filter === 'all' ||
+        (filter === 'ready' && isReady(song)) ||
+        (filter === 'processing' && !isReady(song)) ||
+        (filter === 'lyrics' && Boolean(song.lyrics));
+      return matchesQuery && matchesFilter;
+    });
+  }, [filter, query, songs]);
+
+  const selectedSong = songs.find((song) => song.id === selectedId) || null;
+  const readyCount = songs.filter(isReady).length;
+  const lyricsCount = songs.filter((song) => Boolean(song.lyrics)).length;
+  const averageScore = songs.length
+    ? Math.round(songs.reduce((total, song) => total + metadataScore(song), 0) / songs.length)
+    : 0;
+
+  const handleLogin = async (event: FormEvent) => {
+    event.preventDefault();
+    setAuthError('');
     try {
       const response = await fetch('/api/control/verify', {
         method: 'POST',
@@ -28,16 +152,15 @@ export default function ControlPage() {
 
       if (response.ok) {
         setIsAuthenticated(true);
-        setSecretInput('');
         return;
       }
-      setError(
+      setAuthError(
         response.status === 503
-          ? 'Control panel is not configured.'
-          : 'Invalid secret. Please try again.'
+          ? 'El panel no esta configurado.'
+          : 'Clave incorrecta. Intenta de nuevo.'
       );
     } catch {
-      setError('Unable to contact the authentication service.');
+      setAuthError('No fue posible contactar el servicio de autenticacion.');
     } finally {
       setSecretInput('');
     }
@@ -48,140 +171,385 @@ export default function ControlPage() {
       await fetch('/api/control/verify', { method: 'DELETE' });
     } finally {
       setIsAuthenticated(false);
-      setSecretInput('');
+      setSongs([]);
     }
   };
 
+  const copyMetadata = async () => {
+    if (!selectedSong) return;
+    const text = [
+      selectedSong.title || 'Sin titulo',
+      `Artista: ${selectedSong.artist || 'Iyari Gomez'}`,
+      `Autor: ${selectedSong.author || 'Iyari Cancino Gomez'}`,
+      selectedSong.prompt ? `Concepto: ${selectedSong.prompt}` : '',
+      selectedSong.lyrics ? `\n${selectedSong.lyrics}` : '',
+    ]
+      .filter(Boolean)
+      .join('\n');
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1600);
+  };
+
+  const exportMetadata = () => {
+    if (!selectedSong) return;
+    const blob = new Blob([JSON.stringify(selectedSong, null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `${selectedSong.title || selectedSong.id}-metadata.json`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
   if (isCheckingAuth) {
-    return <div className="min-h-screen bg-black" aria-busy="true" />;
+    return (
+      <main className="studio-shell flex min-h-screen items-center justify-center" aria-busy="true">
+        <div className="studio-loader" />
+      </main>
+    );
   }
 
   if (!isAuthenticated) {
     return (
-      <div className="min-h-screen bg-black text-white flex items-center justify-center p-4">
-        <div className="w-full max-w-md">
-          <div className="bg-zinc-900 rounded-2xl border border-zinc-800 p-8 space-y-6">
-            <div className="text-center space-y-2">
-              <h1 className="text-3xl font-bold">Control Panel</h1>
-              <p className="text-gray-400">Enter secret to access</p>
-            </div>
-
-            <form onSubmit={handleLogin} className="space-y-4">
-              <div>
-                <input
-                  type="password"
-                  value={secretInput}
-                  onChange={(e) => setSecretInput(e.target.value)}
-                  placeholder="Enter secret..."
-                  className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-white"
-                  autoFocus
-                />
-              </div>
-
-              {error && (
-                <div className="bg-red-900/20 border border-red-800 rounded-lg p-3 text-red-400 text-sm">
-                  {error}
-                </div>
-              )}
-
-              <button
-                type="submit"
-                className="w-full bg-white text-black font-semibold py-3 px-6 rounded-full hover:bg-gray-200 transition-all duration-200"
-              >
-                Access Control Panel
-              </button>
-            </form>
-
-            <div className="text-center text-sm text-gray-500">
-              <p>Hint: Check .env file for the secret</p>
-            </div>
-          </div>
+      <main className="studio-shell flex min-h-screen items-center justify-center p-5 text-white">
+        <div className="absolute inset-0 overflow-hidden">
+          <div className="studio-orb studio-orb-one" />
+          <div className="studio-orb studio-orb-two" />
         </div>
-      </div>
+        <section className="studio-panel relative w-full max-w-md overflow-hidden rounded-[2rem] p-8 sm:p-10">
+          <div className="mb-10 flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <div className="brand-mark">S</div>
+              <div>
+                <p className="text-sm font-semibold tracking-[0.22em] text-white">SUNOPO</p>
+                <p className="text-xs text-zinc-500">Creator operations</p>
+              </div>
+            </div>
+            <span className="studio-pill">PRIVATE</span>
+          </div>
+
+          <div className="mb-8">
+            <p className="mb-3 text-xs font-medium uppercase tracking-[0.24em] text-amber-300">
+              Acceso al estudio
+            </p>
+            <h1 className="text-4xl font-semibold leading-tight tracking-[-0.04em]">
+              Tu catalogo.
+              <br />
+              Bajo control.
+            </h1>
+            <p className="mt-4 max-w-sm text-sm leading-6 text-zinc-400">
+              Gestiona metadata, calidad y distribucion desde un solo espacio creativo.
+            </p>
+          </div>
+
+          <form onSubmit={handleLogin} className="space-y-4">
+            <label
+              htmlFor="studio-secret"
+              className="block text-xs font-medium uppercase tracking-[0.18em] text-zinc-500"
+            >
+              Clave del estudio
+            </label>
+            <input
+              id="studio-secret"
+              type="password"
+              value={secretInput}
+              onChange={(event) => setSecretInput(event.target.value)}
+              placeholder="Introduce tu clave"
+              className="studio-input w-full rounded-2xl px-5 py-4 text-sm outline-none"
+              autoFocus
+              required
+            />
+            {authError && (
+              <p className="rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+                {authError}
+              </p>
+            )}
+            <button
+              type="submit"
+              className="studio-primary w-full rounded-2xl px-5 py-4 text-sm font-semibold"
+            >
+              Entrar al estudio
+            </button>
+          </form>
+        </section>
+      </main>
     );
   }
 
   return (
-    <div className="min-h-screen bg-black text-white p-4">
-      <div className="max-w-6xl mx-auto space-y-6">
-        {/* Header */}
-        <div className="flex justify-between items-center">
-          <div>
-            <h1 className="text-3xl font-bold">Control Panel</h1>
-            <p className="text-gray-400">BlackMamba Administration</p>
-          </div>
-          <button
-            onClick={handleLogout}
-            className="bg-zinc-800 hover:bg-zinc-700 text-white font-medium py-2 px-6 rounded-full transition-all duration-200 border border-zinc-700"
-          >
-            Logout
-          </button>
-        </div>
-
-        {/* Stats Grid */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <div className="bg-zinc-900 rounded-xl border border-zinc-800 p-6">
-            <h3 className="text-gray-400 text-sm font-medium mb-2">System Status</h3>
-            <p className="text-2xl font-bold text-green-400">Active</p>
-          </div>
-
-          <div className="bg-zinc-900 rounded-xl border border-zinc-800 p-6">
-            <h3 className="text-gray-400 text-sm font-medium mb-2">Total Generations</h3>
-            <p className="text-2xl font-bold">0</p>
-          </div>
-
-          <div className="bg-zinc-900 rounded-xl border border-zinc-800 p-6">
-            <h3 className="text-gray-400 text-sm font-medium mb-2">Last Generated</h3>
-            <p className="text-lg font-medium">
-              Never
-            </p>
-          </div>
-        </div>
-
-        {/* Configuration */}
-        <div className="bg-zinc-900 rounded-xl border border-zinc-800 p-6 space-y-4">
-          <h2 className="text-xl font-bold">Configuration</h2>
-          
-          <div className="space-y-3">
-            <div className="flex justify-between items-center py-3 border-b border-zinc-800">
-              <div>
-                <p className="font-medium">Audio Generation</p>
-                <p className="text-sm text-gray-400">Mock audio generation endpoint</p>
-              </div>
-              <span className="text-green-400 text-sm font-medium">Enabled</span>
-            </div>
-
-            <div className="flex justify-between items-center py-3 border-b border-zinc-800">
-              <div>
-                <p className="font-medium">Display Page</p>
-                <p className="text-sm text-gray-400">Public display interface</p>
-              </div>
-              <a
-                href="/display"
-                className="text-blue-400 hover:text-blue-300 text-sm font-medium"
-              >
-                Visit →
-              </a>
-            </div>
-
-            <div className="flex justify-between items-center py-3">
-              <div>
-                <p className="font-medium">API Endpoint</p>
-                <p className="text-sm text-gray-400">/api/generate</p>
-              </div>
-              <span className="text-green-400 text-sm font-medium">Active</span>
+    <main className="studio-shell min-h-screen text-zinc-100">
+      <div className="mx-auto flex min-h-screen max-w-[1800px]">
+        <aside className="hidden w-64 shrink-0 border-r border-white/[0.06] px-5 py-7 xl:flex xl:flex-col">
+          <div className="mb-10 flex items-center gap-3 px-2">
+            <div className="brand-mark">S</div>
+            <div>
+              <p className="text-sm font-semibold tracking-[0.22em]">SUNOPO</p>
+              <p className="text-[11px] text-zinc-600">Studio OS</p>
             </div>
           </div>
-        </div>
 
-        {/* Recent Activity */}
-        <div className="bg-zinc-900 rounded-xl border border-zinc-800 p-6">
-          <h2 className="text-xl font-bold mb-4">Recent Activity</h2>
-          <div className="text-gray-400 text-sm">
-            <p>No recent activity to display</p>
+          <nav className="space-y-1">
+            <button className="studio-nav studio-nav-active w-full" aria-current="page">
+              Catalogo
+            </button>
+            <Link href="/display" className="studio-nav block">
+              Crear musica
+            </Link>
+            <button className="studio-nav w-full">Distribucion</button>
+            <button className="studio-nav w-full">Analitica</button>
+          </nav>
+
+          <div className="mt-auto space-y-4">
+            <div className="rounded-2xl border border-amber-300/10 bg-amber-300/[0.04] p-4">
+              <p className="text-xs font-semibold text-amber-200">Suno conectado</p>
+              <p className="mt-1 text-xs leading-5 text-zinc-500">
+                Sesion protegida y lista para sincronizar.
+              </p>
+            </div>
+            <button onClick={handleLogout} className="studio-nav w-full">
+              Cerrar sesion
+            </button>
+          </div>
+        </aside>
+
+        <div className="min-w-0 flex-1">
+          <header className="flex flex-col gap-5 border-b border-white/[0.06] px-5 py-6 lg:flex-row lg:items-center lg:justify-between lg:px-8">
+            <div>
+              <p className="text-xs font-medium uppercase tracking-[0.22em] text-zinc-600">
+                Creator workspace
+              </p>
+              <h1 className="mt-1 text-2xl font-semibold tracking-[-0.03em]">
+                Catalogo maestro
+              </h1>
+            </div>
+            <div className="flex flex-1 items-center gap-3 lg:max-w-2xl lg:justify-end">
+              <label className="studio-search flex min-w-0 flex-1 items-center gap-3 rounded-2xl px-4 py-3 lg:max-w-md">
+                <span className="text-zinc-600">/</span>
+                <input
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder="Buscar titulo, artista o concepto"
+                  className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-zinc-600"
+                />
+              </label>
+              <Link href="/display" className="studio-primary whitespace-nowrap rounded-2xl px-5 py-3 text-sm font-semibold">
+                + Nueva obra
+              </Link>
+            </div>
+          </header>
+
+          <div className="grid gap-5 p-5 lg:p-8 2xl:grid-cols-[minmax(0,1fr)_360px]">
+            <div className="min-w-0 space-y-5">
+              <section className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+                {[
+                  ['Obras', songs.length, 'Catalogo total'],
+                  ['Listas', readyCount, 'Audio terminado'],
+                  ['Con letra', lyricsCount, 'Listas para metadata'],
+                  ['Calidad', `${averageScore}%`, 'Completitud media'],
+                ].map(([label, value, caption]) => (
+                  <article key={label} className="studio-card rounded-2xl p-5">
+                    <p className="text-xs font-medium uppercase tracking-[0.16em] text-zinc-600">
+                      {label}
+                    </p>
+                    <p className="mt-3 text-3xl font-semibold tracking-[-0.04em]">{value}</p>
+                    <p className="mt-1 text-xs text-zinc-500">{caption}</p>
+                  </article>
+                ))}
+              </section>
+
+              <section className="studio-panel overflow-hidden rounded-3xl">
+                <div className="flex flex-col gap-4 border-b border-white/[0.06] p-5 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <h2 className="font-semibold">Biblioteca creativa</h2>
+                    <p className="mt-1 text-xs text-zinc-500">
+                      {filteredSongs.length} obras en esta vista
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {filters.map((item) => (
+                      <button
+                        key={item.value}
+                        onClick={() => setFilter(item.value)}
+                        aria-pressed={filter === item.value}
+                        className={`rounded-full px-3 py-1.5 text-xs transition ${
+                          filter === item.value
+                            ? 'bg-white text-black'
+                            : 'bg-white/[0.04] text-zinc-500 hover:text-white'
+                        }`}
+                      >
+                        {item.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {catalogError && (
+                  <div className="m-5 rounded-2xl border border-amber-400/20 bg-amber-400/[0.06] p-4 text-sm text-amber-200">
+                    {catalogError}. Verifica tu sesion de Suno y vuelve a cargar.
+                  </div>
+                )}
+
+                <div className="overflow-x-auto">
+                  <div className="min-w-[720px]">
+                    <div className="grid grid-cols-[minmax(260px,1.5fr)_140px_110px_120px] gap-4 border-b border-white/[0.05] px-5 py-3 text-[10px] font-semibold uppercase tracking-[0.18em] text-zinc-600">
+                      <span>Obra</span>
+                      <span>Estado</span>
+                      <span>Metadata</span>
+                      <span>Creada</span>
+                    </div>
+                    {isLoading ? (
+                      <div className="space-y-2 p-4">
+                        {[1, 2, 3, 4, 5].map((item) => (
+                          <div key={item} className="h-16 animate-pulse rounded-xl bg-white/[0.03]" />
+                        ))}
+                      </div>
+                    ) : filteredSongs.length ? (
+                      filteredSongs.map((song, index) => {
+                        const score = metadataScore(song);
+                        const active = selectedSong?.id === song.id;
+                        return (
+                          <button
+                            key={song.id}
+                            onClick={() => setSelectedId(song.id)}
+                            className={`grid w-full grid-cols-[minmax(260px,1.5fr)_140px_110px_120px] items-center gap-4 border-b border-white/[0.04] px-5 py-3 text-left transition ${
+                              active ? 'bg-amber-300/[0.06]' : 'hover:bg-white/[0.025]'
+                            }`}
+                          >
+                            <span className="flex min-w-0 items-center gap-3">
+                              <span className={`cover-gradient cover-gradient-${(index % 4) + 1}`}>
+                                {(song.title || 'S').charAt(0).toUpperCase()}
+                              </span>
+                              <span className="min-w-0">
+                                <span className="block truncate text-sm font-medium">
+                                  {song.title || 'Obra sin titulo'}
+                                </span>
+                                <span className="mt-1 block truncate text-xs text-zinc-600">
+                                  {song.artist || 'Iyari Gomez'}
+                                </span>
+                              </span>
+                            </span>
+                            <span>
+                              <span
+                                className={`status-dot ${isReady(song) ? 'status-ready' : 'status-processing'}`}
+                              />
+                              <span className="text-xs text-zinc-400">
+                                {isReady(song) ? 'Lista' : 'Procesando'}
+                              </span>
+                            </span>
+                            <span className="flex items-center gap-2">
+                              <span className="h-1.5 w-12 overflow-hidden rounded-full bg-white/[0.06]">
+                                <span
+                                  className="block h-full rounded-full bg-amber-300"
+                                  style={{ width: `${score}%` }}
+                                />
+                              </span>
+                              <span className="text-xs text-zinc-500">{score}%</span>
+                            </span>
+                            <span className="text-xs text-zinc-500">{formatDate(song.created_at)}</span>
+                          </button>
+                        );
+                      })
+                    ) : (
+                      <div className="px-5 py-16 text-center">
+                        <p className="text-sm text-zinc-400">No hay obras en esta vista.</p>
+                        <p className="mt-1 text-xs text-zinc-600">
+                          Ajusta los filtros o crea una nueva pieza.
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </section>
+            </div>
+
+            <aside className="studio-panel h-fit overflow-hidden rounded-3xl 2xl:sticky 2xl:top-8">
+              {selectedSong ? (
+                <>
+                  <div className="inspector-cover relative flex h-44 items-end p-6">
+                    <div>
+                      <span className="studio-pill">SELECTED WORK</span>
+                      <h2 className="mt-3 max-w-xs text-2xl font-semibold tracking-[-0.04em]">
+                        {selectedSong.title || 'Obra sin titulo'}
+                      </h2>
+                    </div>
+                  </div>
+                  <div className="space-y-6 p-6">
+                    {selectedSong.audio_url && (
+                      <audio controls src={selectedSong.audio_url} className="h-10 w-full" />
+                    )}
+
+                    <div>
+                      <div className="mb-3 flex items-center justify-between">
+                        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                          Preparacion
+                        </p>
+                        <span className="text-xs font-semibold text-amber-200">
+                          {metadataScore(selectedSong)}%
+                        </span>
+                      </div>
+                      <div className="h-1.5 overflow-hidden rounded-full bg-white/[0.06]">
+                        <div
+                          className="h-full rounded-full bg-gradient-to-r from-amber-400 to-orange-300"
+                          style={{ width: `${metadataScore(selectedSong)}%` }}
+                        />
+                      </div>
+                    </div>
+
+                    <dl className="space-y-4">
+                      {[
+                        ['Artista', selectedSong.artist || 'Iyari Gomez'],
+                        ['Autor', selectedSong.author || 'Iyari Cancino Gomez'],
+                        ['Estado', isReady(selectedSong) ? 'Master listo' : 'En produccion'],
+                        ['Distribucion', 'Pendiente'],
+                      ].map(([label, value]) => (
+                        <div key={label} className="flex items-center justify-between gap-4">
+                          <dt className="text-xs text-zinc-600">{label}</dt>
+                          <dd className="text-right text-xs font-medium text-zinc-300">{value}</dd>
+                        </div>
+                      ))}
+                    </dl>
+
+                    {selectedSong.prompt && (
+                      <div className="rounded-2xl bg-black/30 p-4">
+                        <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-zinc-600">
+                          Concepto
+                        </p>
+                        <p className="line-clamp-4 text-xs leading-5 text-zinc-400">
+                          {selectedSong.prompt}
+                        </p>
+                      </div>
+                    )}
+
+                    <div className="grid grid-cols-2 gap-2">
+                      <button onClick={copyMetadata} className="studio-secondary rounded-xl px-3 py-3 text-xs font-medium">
+                        {copied ? 'Copiado' : 'Copiar metadata'}
+                      </button>
+                      <button onClick={exportMetadata} className="studio-secondary rounded-xl px-3 py-3 text-xs font-medium">
+                        Exportar JSON
+                      </button>
+                    </div>
+                    <a
+                      href="https://soundcloud.com/upload"
+                      target="_blank"
+                      rel="noreferrer"
+                      className="studio-primary block rounded-xl px-4 py-3 text-center text-xs font-semibold"
+                    >
+                      Preparar para SoundCloud
+                    </a>
+                  </div>
+                </>
+              ) : (
+                <div className="p-10 text-center text-sm text-zinc-600">
+                  Selecciona una obra para revisar sus metadatos.
+                </div>
+              )}
+            </aside>
           </div>
         </div>
       </div>
-    </div>
+    </main>
   );
 }

--- a/app/display/page.tsx
+++ b/app/display/page.tsx
@@ -1,11 +1,22 @@
 'use client';
 
+import Image from 'next/image';
 import { useState } from 'react';
+
+interface AudioClip {
+  id: string;
+  title?: string;
+  image_url?: string;
+  audio_url?: string;
+  metadata?: {
+    tags?: string;
+  };
+}
 
 export default function DisplayPage() {
   const [isGenerating, setIsGenerating] = useState(false);
   const [progress, setProgress] = useState(0);
-  const [clips, setClips] = useState<any[]>([]);
+  const [clips, setClips] = useState<AudioClip[]>([]);
   const [error, setError] = useState<string | null>(null);
 
   const [prompt, setPrompt] = useState('');
@@ -24,9 +35,13 @@ export default function DisplayPage() {
     setClips([]);
     setError(null);
 
+    let progressInterval: ReturnType<typeof setInterval> | undefined;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 300_000);
+
     try {
       // Simulate progress
-      const progressInterval = setInterval(() => {
+      progressInterval = setInterval(() => {
         setProgress((prev) => {
           if (prev >= 95) {
             clearInterval(progressInterval);
@@ -48,26 +63,37 @@ export default function DisplayPage() {
           is_custom: isCustom,
           wait_audio: true,
         }),
+        signal: controller.signal,
       });
 
-      clearInterval(progressInterval);
+      if (progressInterval) clearInterval(progressInterval);
 
+      const contentType = response.headers.get('content-type') || '';
+      const data = contentType.includes('application/json')
+        ? await response.json()
+        : null;
       if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.error || 'Error al generar audio');
+        throw new Error(data?.error || 'Error al generar audio');
       }
 
-      const data = await response.json();
-      if (data.success && data.clips) {
+      if (data?.success && Array.isArray(data.clips)) {
         setClips(data.clips);
         setProgress(100);
       } else {
         throw new Error('No se recibieron pistas generadas');
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Error desconocido');
+      const message =
+        err instanceof Error && err.name === 'AbortError'
+          ? 'La generación tardó demasiado. Inténtalo de nuevo.'
+          : err instanceof Error
+            ? err.message
+            : 'Error desconocido';
+      setError(message);
       setProgress(0);
     } finally {
+      if (progressInterval) clearInterval(progressInterval);
+      clearTimeout(timeout);
       setIsGenerating(false);
     }
   };
@@ -204,8 +230,14 @@ export default function DisplayPage() {
                 {clips.map((clip) => (
                   <div key={clip.id} className="bg-zinc-800/50 rounded-2xl overflow-hidden border border-zinc-700 flex flex-col md:flex-row">
                     {clip.image_url && (
-                      <div className="w-full md:w-48 h-48 flex-shrink-0">
-                        <img src={clip.image_url} alt={clip.title} className="w-full h-full object-cover" />
+                      <div className="relative w-full md:w-48 h-48 flex-shrink-0">
+                        <Image
+                          src={clip.image_url}
+                          alt={clip.title || 'Portada del audio'}
+                          fill
+                          sizes="(min-width: 768px) 192px, 100vw"
+                          className="object-cover"
+                        />
                       </div>
                     )}
                     <div className="p-6 flex-grow flex flex-col justify-between space-y-4">
@@ -229,13 +261,13 @@ export default function DisplayPage() {
 
                       <div className="flex space-x-3">
                         <button
-                          onClick={() => handleDownload(clip.audio_url, `${clip.title || 'audio'}.mp3`)}
+                          onClick={() => handleDownload(clip.audio_url || '', `${clip.title || 'audio'}.mp3`)}
                           className="flex-1 bg-zinc-700 hover:bg-zinc-600 text-white text-sm font-medium py-2 px-4 rounded-lg transition-colors border border-zinc-600"
                         >
                           Descargar
                         </button>
                         <button
-                          onClick={() => handleShare(clip.audio_url, clip.title)}
+                          onClick={() => handleShare(clip.audio_url || '', clip.title || 'Audio')}
                           className="flex-1 bg-zinc-700 hover:bg-zinc-600 text-white text-sm font-medium py-2 px-4 rounded-lg transition-colors border border-zinc-600"
                         >
                           Compartir

--- a/app/globals.css
+++ b/app/globals.css
@@ -16,3 +16,187 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   min-height: 100vh;
 }
+
+button,
+a,
+input {
+  -webkit-tap-highlight-color: transparent;
+}
+
+.studio-shell {
+  background:
+    radial-gradient(circle at 76% -10%, rgba(164, 110, 37, 0.12), transparent 32rem),
+    radial-gradient(circle at 16% 110%, rgba(98, 57, 30, 0.1), transparent 34rem),
+    #090909;
+}
+
+.studio-panel,
+.studio-card {
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  background: rgba(18, 18, 18, 0.88);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.22);
+  backdrop-filter: blur(24px);
+}
+
+.studio-card {
+  background: linear-gradient(145deg, rgba(24, 24, 24, 0.92), rgba(15, 15, 15, 0.92));
+}
+
+.brand-mark {
+  display: grid;
+  width: 2.35rem;
+  height: 2.35rem;
+  place-items: center;
+  border: 1px solid rgba(253, 224, 71, 0.35);
+  border-radius: 0.85rem;
+  background: linear-gradient(145deg, #f5d56d, #8c5728);
+  box-shadow: 0 8px 30px rgba(196, 129, 45, 0.2);
+  color: #100d08;
+  font-size: 0.9rem;
+  font-weight: 800;
+}
+
+.studio-pill {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid rgba(253, 224, 71, 0.16);
+  border-radius: 999px;
+  background: rgba(253, 224, 71, 0.06);
+  padding: 0.35rem 0.6rem;
+  color: #dbc789;
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+}
+
+.studio-input,
+.studio-search {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.035);
+  color: white;
+  transition: border-color 160ms ease, background 160ms ease;
+}
+
+.studio-input:focus,
+.studio-search:focus-within {
+  border-color: rgba(250, 204, 21, 0.35);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.studio-primary {
+  background: linear-gradient(135deg, #f5df91, #bf7a35);
+  box-shadow: 0 10px 28px rgba(184, 111, 39, 0.12);
+  color: #171109;
+  transition: filter 160ms ease, transform 160ms ease;
+}
+
+.studio-primary:hover {
+  filter: brightness(1.08);
+  transform: translateY(-1px);
+}
+
+.studio-secondary {
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  background: rgba(255, 255, 255, 0.035);
+  color: #d4d4d8;
+  transition: background 160ms ease, color 160ms ease;
+}
+
+.studio-secondary:hover {
+  background: rgba(255, 255, 255, 0.07);
+  color: white;
+}
+
+.studio-nav {
+  border-radius: 0.9rem;
+  padding: 0.75rem 0.85rem;
+  color: #71717a;
+  font-size: 0.8rem;
+  text-align: left;
+  transition: background 160ms ease, color 160ms ease;
+}
+
+.studio-nav:hover,
+.studio-nav-active {
+  background: rgba(255, 255, 255, 0.045);
+  color: #f4f4f5;
+}
+
+.cover-gradient {
+  display: grid;
+  width: 2.55rem;
+  height: 2.55rem;
+  flex: none;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.75rem;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.cover-gradient-1 { background: linear-gradient(145deg, #5b291e, #17100f); }
+.cover-gradient-2 { background: linear-gradient(145deg, #243b38, #101716); }
+.cover-gradient-3 { background: linear-gradient(145deg, #47395c, #15121b); }
+.cover-gradient-4 { background: linear-gradient(145deg, #5a4922, #18150e); }
+
+.status-dot {
+  display: inline-block;
+  width: 0.4rem;
+  height: 0.4rem;
+  margin-right: 0.5rem;
+  border-radius: 999px;
+}
+
+.status-ready {
+  background: #6ee7b7;
+  box-shadow: 0 0 0 4px rgba(110, 231, 183, 0.08);
+}
+
+.status-processing {
+  background: #facc15;
+  box-shadow: 0 0 0 4px rgba(250, 204, 21, 0.08);
+}
+
+.inspector-cover {
+  background:
+    linear-gradient(0deg, rgba(10, 10, 10, 0.92), rgba(10, 10, 10, 0.08)),
+    radial-gradient(circle at 70% 20%, rgba(239, 190, 92, 0.55), transparent 32%),
+    linear-gradient(135deg, #5d2c1d, #17120f 62%);
+}
+
+.studio-orb {
+  position: absolute;
+  border-radius: 999px;
+  filter: blur(90px);
+  opacity: 0.22;
+}
+
+.studio-orb-one {
+  top: -8rem;
+  right: 5%;
+  width: 26rem;
+  height: 26rem;
+  background: #a96a2f;
+}
+
+.studio-orb-two {
+  bottom: -12rem;
+  left: 4%;
+  width: 28rem;
+  height: 28rem;
+  background: #4d2f21;
+}
+
+.studio-loader {
+  width: 2rem;
+  height: 2rem;
+  border: 2px solid rgba(255, 255, 255, 0.08);
+  border-top-color: #e7c774;
+  border-radius: 999px;
+  animation: studio-spin 700ms linear infinite;
+}
+
+@keyframes studio-spin {
+  to { transform: rotate(360deg); }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,8 +2,8 @@ import type { Metadata } from "next";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "BlackMamba",
-  description: "Audio generation app with Suno-inspired layout",
+  title: "Sunopo Studio",
+  description: "Professional catalog, metadata, and distribution workspace for Suno creators",
 };
 
 export default function RootLayout({
@@ -12,7 +12,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="es">
       <body className="antialiased">
         {children}
       </body>

--- a/config.py
+++ b/config.py
@@ -1,5 +1,7 @@
+import logging
 import os
 from pathlib import Path
+
 from dotenv import load_dotenv
 
 # Load .env if present
@@ -13,13 +15,14 @@ REPORTS_DIR = Path(os.environ.get("SUNOPO_REPORTS_DIR", BASE_DIR / "reports"))
 # Session file path (sensitive)
 SESSION_ID_PATH = Path(
     os.environ.get(
-        "SUNO_SESSION_ID_PATH", "/Users/blackmamba/suno_downloader/suno_session.txt"
+        "SUNO_SESSION_ID_PATH", BASE_DIR / ".data" / "suno_session.txt"
     )
 )
 
 # Flask settings
 FLASK_HOST = os.environ.get("FLASK_HOST", "0.0.0.0")
 FLASK_PORT = int(os.environ.get("FLASK_PORT", "5555"))
+FLASK_DEBUG = os.environ.get("FLASK_DEBUG", "false").lower() in ("1", "true", "yes")
 
 # S3 / storage settings
 USE_S3 = os.environ.get("SUNOPO_USE_S3", "false").lower() in ("1", "true", "yes")
@@ -36,11 +39,15 @@ SESSION_FERNET_KEY = os.environ.get("SESSION_FERNET_KEY")  # base64 key for Fern
 def ensure_dirs():
     EXPORTS_DIR.mkdir(parents=True, exist_ok=True)
     REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    SESSION_ID_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 
 # Helper to read session id safely
 def read_session_id():
     try:
         return SESSION_ID_PATH.read_text().strip()
-    except Exception:
+    except FileNotFoundError:
+        return None
+    except OSError:
+        logging.getLogger(__name__).exception("Unable to read the Suno session file")
         return None

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,37 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  compress: true,
+  poweredByHeader: false,
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "cdn1.suno.ai",
+      },
+      {
+        protocol: "https",
+        hostname: "cdn2.suno.ai",
+      },
+    ],
+    formats: ["image/avif", "image/webp"],
+  },
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=()",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "next": "16.1.3",

--- a/sessions.py
+++ b/sessions.py
@@ -9,7 +9,7 @@ class SessionStore:
     def __init__(
         self, redis_url: str = None, ttl: int = 86400, fernet_key: Optional[str] = None
     ):
-        self.ttl = ttl
+        self.ttl_seconds = ttl
         if redis_url:
             self.client = redis.from_url(redis_url)
         else:
@@ -44,7 +44,7 @@ class SessionStore:
             raise RuntimeError("Redis client not configured")
         token = uuid.uuid4().hex
         value = self._encrypt(cookie_str)
-        self.client.setex(token, self.ttl, value)
+        self.client.setex(token, self.ttl_seconds, value)
         return token
 
     def get_session(self, token: str) -> Optional[str]:

--- a/suno_client.py
+++ b/suno_client.py
@@ -1,6 +1,8 @@
-from typing import List, Optional
-from suno import Suno, ModelVersions
+import random
 import time
+from typing import List, Optional
+
+from suno import Suno
 
 
 class SunoClient:
@@ -8,6 +10,7 @@ class SunoClient:
         # cookie can be the raw cookie string required by Suno
         self.cookie = cookie
         self.session_getter = session_getter
+        self._client = None
 
     def _get_cookie(self):
         if self.cookie:
@@ -20,20 +23,29 @@ class SunoClient:
         self, func, *args, retries: int = 3, backoff_base: float = 0.5, **kwargs
     ):
         attempts = 0
+        last_error = None
         while attempts < retries:
             try:
                 return func(*args, **kwargs)
             except Exception as e:
+                last_error = e
                 attempts += 1
+                if attempts >= retries:
+                    break
                 wait = backoff_base * (2 ** (attempts - 1))
-                # add jitter
-                time.sleep(wait + (0.1 * attempts))
-        raise
+                time.sleep(wait + random.uniform(0, wait * 0.1))
+        if last_error is not None:
+            raise last_error
+        raise RuntimeError("Request failed without an exception")
+
+    def _get_client(self):
+        if self._client is None:
+            self._client = Suno(cookie=self._get_cookie())
+        return self._client
 
     def list_songs(self, page: int = 1, limit: int = 100) -> List:
         # Basic wrapper using _request_with_retry
-        cookie = self._get_cookie()
-        client = Suno(cookie=cookie)
+        client = self._get_client()
         return self._request_with_retry(client.songs.list, page=page, limit=limit)
 
     def iter_songs(
@@ -42,8 +54,7 @@ class SunoClient:
         """
         Generator that yields songs from Suno in pages. Handles retries and stops when an empty page is returned or when max_pages reached.
         """
-        cookie = self._get_cookie()
-        client = Suno(cookie=cookie)
+        client = self._get_client()
         page = start_page
         pages_yielded = 0
         while True:

--- a/tests/test_api_pagination.py
+++ b/tests/test_api_pagination.py
@@ -1,5 +1,3 @@
-import json
-import pytest
 from types import SimpleNamespace
 
 from app import app
@@ -76,3 +74,10 @@ def test_api_songs_all(monkeypatch):
         assert "items" in data
         assert len(data["items"]) == 3
         assert data["has_more"] is False
+
+
+def test_download_rejects_invalid_song_id():
+    with app.test_client() as client:
+        response = client.get("/api/download/not%20safe")
+
+    assert response.status_code == 400

--- a/tests/test_secure_session.py
+++ b/tests/test_secure_session.py
@@ -1,7 +1,3 @@
-import json
-import pytest
-from types import SimpleNamespace
-
 from app import app, session_store
 
 
@@ -51,3 +47,12 @@ def test_create_and_validate_session(monkeypatch):
         assert rv3.status_code == 200
         rv4 = c.get("/api/session/validate")
         assert rv4.get_json()["valid"] is False
+
+
+def test_malformed_bearer_header_does_not_crash(monkeypatch):
+    monkeypatch.setattr("app.read_session_id", lambda: None)
+
+    with app.test_client() as client:
+        response = client.get("/api/songs", headers={"Authorization": "Bearer"})
+
+    assert response.status_code == 400


### PR DESCRIPTION
Sunopo should be more than a generation form: creators need one place to understand their catalog, improve release readiness, and move finished work toward distribution. This change hardens the platform and turns the private control area into a premium creator operations studio.

## What changed

- Rebuilds `/control` as a cinematic dark workspace with live catalog search, filters, release-readiness metrics, metadata quality scores, track inspection, audio preview, metadata export, and a SoundCloud handoff.
- Adds a protected Next.js catalog proxy that paginates up to 1,000 Suno works while preserving server-side session credentials.
- Moves control authentication to a reusable server-validated, signed HttpOnly cookie and removes public/default secrets.
- Fixes Redis TTL handling, improves Suno client reuse and retry behavior, and makes session paths portable.
- Validates generation input and song IDs, prevents unsafe file access, adds upstream timeouts, and returns explicit API failures instead of mock success data.
- Adds security headers, environment documentation, accessibility states, and regression coverage for malformed authorization and invalid download identifiers.

## Review notes

The studio derives readiness and metadata completeness from fields currently returned by Suno; distribution status remains intentionally pending until a publishing provider confirms delivery. Next.js image optimization is restricted to known Suno CDN hosts to avoid creating an open image proxy.

Local automated suites could not run in this workspace because Node/npm and a functional Python runtime are unavailable; static diff integrity checks completed successfully.