### PR TITLE
Productize Sunopo as BlackMamba music control plane

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,26 @@
-# Control Panel Secret
-# Used to protect the /control page
-CONTROL_SECRET=your_secret_here
+# Web -> backend
+BACKEND_URL=http://localhost:5555
+
+# Redis-backed session storage
+REDIS_URL=redis://localhost:6379/0
+SESSION_TTL_SECONDS=86400
+# Generate a real Fernet key for deployments that persist encrypted sessions.
+SESSION_FERNET_KEY=
+
+# Provider session fallback (development only)
+SUNO_SESSION_ID_PATH=./.secrets/suno_session.txt
+
+# Local storage
+SUNOPO_EXPORTS_DIR=./exports
+SUNOPO_REPORTS_DIR=./reports
+
+# Optional S3 storage
+SUNOPO_USE_S3=false
+SUNOPO_S3_BUCKET=
+AWS_REGION=us-east-1
+
+# Legacy /control client-side gate. Development only; do not use as production auth.
+NEXT_PUBLIC_CONTROL_SECRET=change-me
+
+# UI metadata
+NEXT_PUBLIC_APP_NAME=BlackMamba

--- a/README.md
+++ b/README.md
@@ -1,194 +1,243 @@
-# BlackMamba
+# Sunopo — BlackMamba Music Control Plane
 
-BlackMamba is a Suno-like audio generation interface with a minimal black theme.
+Sunopo is the control plane for the BlackMamba music workflow: generate music, inspect the connected catalog, prepare assets, and progressively automate distribution from one interface.
 
-## Features
+The project started as a minimal Suno-inspired UI. The current codebase is already a hybrid product with a Next.js frontend, a Flask backend, session handling, a Suno client integration, catalog endpoints, audio export utilities, and early distribution automation experiments.
 
-- **Display Page** (`/display`): Public Spanish interface with audio generation, progress tracking, playback, download, and share functionality
-- **Control Panel** (`/control`): Private English administrative interface protected by CONTROL_SECRET
-- **Mock API**: Simulated audio generation with random delays (1.5-3 seconds)
-- **Black Minimal Theme**: Built with TailwindCSS for a sleek, modern look
+## Product direction
 
-## Prerequisites
+Sunopo is not intended to remain a visual clone of another product. The target is a provider-agnostic music operating layer where generation engines, catalog sources, analysis tools, metadata, artwork, publishing destinations, and automation can be connected behind a stable BlackMamba interface.
 
-- Node.js 18+ 
-- npm or yarn
+```text
+Creator
+  |
+  v
+BlackMamba UI
+  |
+  +--> Generate
+  +--> Library
+  +--> Analyze
+  +--> Metadata
+  +--> Artwork
+  +--> Publish
+  +--> Analytics
+        |
+        +--> Suno / future engines
+        +--> Local tools
+        +--> SoundCloud / future destinations
+```
 
-## Setup
+See [`docs/PRODUCT.md`](docs/PRODUCT.md), [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md), and [`ROADMAP.md`](ROADMAP.md) for the product contract and delivery plan.
 
-1. **Clone the repository**
-   ```bash
-   git clone <repository-url>
-   cd Sunopo
-   ```
+## Current capabilities
 
-2. **Install dependencies**
-   ```bash
-   npm install
-   ```
+### Generation
 
-3. **Configure environment variables**
-   ```bash
-   cp .env.example .env.local
-   ```
-   
-   Edit `.env.local` and set your control secret:
-   ```
-   CONTROL_SECRET=your_secret_here
-   ```
+- Public Spanish generation interface at `/display`
+- Prompt-based generation
+- Custom mode with lyrics, tags/style, and title
+- Multiple returned clips
+- Playback, download, artwork preview, and share controls
+- Next.js API proxy at `POST /api/generate`
+- Flask generation backend using `SunoClient`
 
-4. **Run the development server**
-   ```bash
-   npm run dev
-   ```
+### Library and media
 
-5. **Open your browser**
-   - Display page: http://localhost:3000/display
-   - Control panel: http://localhost:3000/control
+The Flask backend includes catalog and media operations such as:
 
-## Usage
+- `GET /api/songs`
+- paginated library retrieval
+- optional full-library iteration
+- title, artwork, audio, video, prompt, lyrics, timestamps, and status data
+- WAV export utilities
+- track-analysis/description helpers
 
-### Display Page
-- Click "Generar Audio" to simulate audio generation
-- Watch the progress bar
-- Once complete, play, download, or share the generated audio
+### Sessions and infrastructure
 
-### Control Panel
-- Access with the CONTROL_SECRET from your environment
-- View system status and statistics
-- Navigate to the display page
+The repository contains infrastructure for:
 
-## Build for Production
-### Installation
+- Redis-backed session storage
+- optional Fernet encryption
+- cookie/header/query session-token resolution
+- local session fallback
+- S3-ready storage configuration
+- Docker/CI work from earlier iterations
 
-1. Clone the repository:
+### Administration
+
+- `/control` provides an early administrative surface
+- system status and product configuration concepts are already represented
+
+**Important:** the current `/control` authentication is client-side and must not be treated as production security. Server-side authentication is a launch blocker.
+
+## Architecture
+
+The current runtime is split into two layers:
+
+```text
+Browser
+  |
+  v
+Next.js 16 / React 19
+  |
+  | POST /api/generate
+  v
+Next.js route handler
+  |
+  | BACKEND_URL
+  v
+Flask :5555
+  |
+  +--> SessionStore / Redis
+  +--> SunoClient
+  +--> catalog endpoints
+  +--> export / analysis tools
+```
+
+The immediate architectural goal is to preserve this split while introducing stable service boundaries so generation providers and publishing destinations can be swapped without rewriting the UI.
+
+## Technology
+
+### Web
+
+- Next.js 16
+- React 19
+- TypeScript
+- Tailwind CSS 4
+
+### Backend
+
+- Python
+- Flask
+- Redis
+- cryptography / Fernet
+- pydub
+- boto3
+- SunoAI client integration
+
+## Local development
+
+### Prerequisites
+
+- Node.js 18+
+- Python 3.10+
+- Redis for server-side sessions
+- ffmpeg if WAV/media conversion is used
+
+### 1. Clone
+
 ```bash
 git clone https://github.com/Blackmvmba88/Sunopo.git
 cd Sunopo
 ```
 
-2. Install dependencies:
+### 2. Frontend
+
 ```bash
 npm install
-```
-
-3. Create environment file:
-```bash
 cp .env.example .env.local
-```
-
-4. Update the `.env.local` file with your secret:
-```env
-NEXT_PUBLIC_CONTROL_SECRET=your-secret-here
-```
-
-### Development
-
-Run the development server:
-
-```bash
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) in your browser.
+The web app runs at `http://localhost:3000` by default.
 
-### Build for Production
+### 3. Backend
 
 ```bash
-npm run build
-npm start
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python app.py
 ```
 
-## Pages
+The Flask backend runs at `http://localhost:5555` by default.
 
-### Display Page - `/display`
-The public-facing page where users can:
-- Click "Generar Audio" to create audio
-- Watch progress bar during generation
-- Play the generated audio
-- Download the audio file
-- Share the audio (uses Web Share API or clipboard fallback)
+### 4. Redis
 
-**Language**: Spanish
+Run Redis locally or set `REDIS_URL` to an accessible instance.
 
-### Control Panel - `/control`
-Protected admin panel requiring a secret to access:
-- View system status
-- Monitor generation statistics
-- Manage configuration
-- View recent activity
+## Environment
 
-**Language**: English
-**Default Secret**: `blackmamba2024` (change in `.env.local`)
+Copy `.env.example` and configure only the values needed for your environment.
 
-> **⚠️ Security Note**: The current implementation uses client-side authentication for simplicity. In a production environment, implement proper server-side authentication with secure session management.
+Core variables include:
 
-## API Routes
+| Variable | Purpose |
+|---|---|
+| `BACKEND_URL` | Next.js -> Flask backend URL |
+| `REDIS_URL` | Redis connection for server-side sessions |
+| `SESSION_TTL_SECONDS` | Session lifetime |
+| `SESSION_FERNET_KEY` | Optional session encryption key |
+| `SUNO_SESSION_ID_PATH` | Local fallback path for the Suno session value |
+| `SUNOPO_EXPORTS_DIR` | Generated/exported media directory |
+| `SUNOPO_REPORTS_DIR` | Reports directory |
+| `SUNOPO_USE_S3` | Enable S3-backed storage where supported |
+| `SUNOPO_S3_BUCKET` | S3 bucket name |
+| `AWS_REGION` | AWS region |
+| `NEXT_PUBLIC_CONTROL_SECRET` | Legacy client-side control secret; development only |
 
-### POST `/api/generate`
-Generates a mock audio file with random delay.
+Do not commit real session cookies, secrets, tokens, or encryption keys.
 
-**Response**:
-```json
-{
-  "success": true,
-  "audioUrl": "/sample-audio.mp3",
-  "message": "Audio generated successfully",
-  "timestamp": "2024-01-18T20:00:00.000Z"
-}
-```
+## API surface
 
-## Customization
+The repository currently exposes or contains handlers for:
 
-### Theme
-The app uses a black minimal theme. To customize:
-- Edit `app/globals.css` for global styles
-- Modify Tailwind classes in component files
+- `POST /api/generate` — generate music
+- `GET /api/songs` — retrieve catalog items
+- `POST /api/session` — create a server-side session token
+- `GET /api/session/validate` — validate session token
+- `DELETE /api/session/<token>` — revoke session token
+- `POST /api/update_session` — legacy/local session update path
+- `POST /api/generate_wav/<song_id>` — WAV export
+- `GET /api/download/<song_id>` — exported WAV download
+- `POST /api/analyze_track/<song_id>` — generate track metadata/description helper
+- `GET /health` — backend health check
 
-### Audio Generation
-The `/api/generate` endpoint currently returns a sample file. To integrate real audio generation:
-1. Update `app/api/generate/route.ts`
-2. Add your audio generation logic
-3. Return the generated audio URL
+This surface will be normalized and versioned before a public release.
 
-### Secret Protection
-To change the control panel secret:
-1. Update `NEXT_PUBLIC_CONTROL_SECRET` in `.env.local`
-2. Restart the development server
+## Product gates
 
-## Project Structure
+Sunopo should not be considered production-ready until the following gates are complete:
 
-```
-Sunopo/
-├── app/
-│   ├── api/
-│   │   └── generate/
-│   │       └── route.ts          # Audio generation API
-│   ├── control/
-│   │   └── page.tsx              # Control panel (private, English)
-│   ├── display/
-│   │   └── page.tsx              # Display page (public, Spanish)
-│   ├── globals.css               # Global styles (black theme)
-│   └── layout.tsx                # Root layout
-├── public/
-│   └── sample-audio.mp3          # Sample audio file
-├── .env.example                  # Environment variables template
-├── .env.local                    # Local environment variables (not committed)
-├── package.json                  # Dependencies
-└── README.md                     # This file
-```
+1. server-side control authentication
+2. session/security hardening
+3. deterministic error contracts across Next.js and Flask
+4. removal of demo/mock fallbacks from production paths
+5. persistent catalog model independent of any single provider
+6. generation job state instead of simulated progress
+7. automated tests for generation, session, library, and export contracts
+8. observability and structured audit logs
+9. deployment configuration and secrets policy
+10. explicit provider-compliance review before external release
 
-## Environment Variables
+## Delivery model
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `NEXT_PUBLIC_CONTROL_SECRET` | Secret to access control panel | `blackmamba2024` |
-| `NEXT_PUBLIC_APP_NAME` | Application name | `BlackMamba` |
+Product work is organized around four vertical slices:
+
+1. **Generate** — reliable job-based generation
+2. **Library** — canonical local catalog and sync
+3. **Prepare** — lyrics, metadata, artwork, audio variants, QA
+4. **Publish** — explicit, auditable delivery to external destinations
+
+See [`ROADMAP.md`](ROADMAP.md) for milestones and acceptance criteria.
+
+## Security posture
+
+Treat all third-party session material as credentials.
+
+- never expose provider session values to browser code
+- prefer HttpOnly server-managed tokens
+- avoid query-string credentials in production
+- use encrypted storage for persisted sensitive values
+- require explicit authorization for publishing or destructive operations
+- keep generation and publishing actions auditable
+
+## Status
+
+**Stage:** pre-alpha productization.
+
+The repository already proves the core integration path. The current focus is turning that prototype into a stable, provider-agnostic product with predictable contracts and safe operations.
 
 ## License
 
-MIT License - feel free to use this project for any purpose.
-
-## Credits
-
-UI inspired by [Suno](https://suno.ai/) with a minimal black theme aesthetic.
+MIT.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,139 @@
+# Sunopo Roadmap
+
+## Goal
+
+Move Sunopo from pre-alpha integration prototype to a reliable BlackMamba music control plane without a full rewrite.
+
+## P0 — Stabilize the existing product
+
+**Outcome:** current generation and catalog paths are predictable enough to build on.
+
+- [ ] Fix missing Redis/session configuration imports in `app.py`
+- [ ] Remove production-path mock catalog fallbacks
+- [ ] Replace client-side `/control` authentication with server-side auth
+- [ ] Define a normalized API error envelope
+- [ ] Add request/correlation IDs
+- [ ] Add backend health checks for Redis, provider connectivity, and storage
+- [ ] Add smoke tests for `/health`, generation proxy, sessions, and song listing
+- [ ] Align README/environment documentation with runtime behavior
+
+**Exit criteria**
+
+- clean startup with and without optional services
+- failures return stable machine-readable errors
+- secrets never need to be exposed to client JavaScript
+- core smoke tests pass in CI
+
+## P1 — Durable generation jobs
+
+**Outcome:** generation becomes a real product workflow instead of a synchronous request plus simulated progress.
+
+- [ ] Introduce `GenerationJob` model
+- [ ] Persist normalized request, provider IDs, status, attempts, timestamps, and errors
+- [ ] Add `POST /api/v1/generation-jobs`
+- [ ] Add `GET /api/v1/generation-jobs/:id`
+- [ ] Normalize returned clips into `Variant` records
+- [ ] Replace fake UI progress with actual job state
+- [ ] Add retry/cancel semantics where provider behavior permits
+- [ ] Preserve prompt, tags, title, custom-mode settings, and provider metadata
+
+**Exit criteria**
+
+- browser refresh does not lose an active/completed generation
+- a failed job can be diagnosed from stored state
+- returned variants survive provider/UI refresh
+
+## P2 — Canonical BlackMamba library
+
+**Outcome:** Sunopo owns its catalog instead of treating a provider library as the database.
+
+- [ ] Add durable `Track`, `Variant`, and `Asset` models
+- [ ] Add provider/source ID mapping
+- [ ] Add checksums for media assets
+- [ ] Sync existing provider library into canonical records
+- [ ] Track lyrics, artwork, audio, video, prompt, status, and timestamps
+- [ ] Add search/filter/pagination over local catalog
+- [ ] Add track workspace page
+- [ ] Add duplicate/version detection
+
+**Exit criteria**
+
+- a track can be reopened without requesting its identity from the provider
+- multiple provider versions can belong to one BlackMamba track
+- catalog search is local and deterministic
+
+## P3 — Preparation pipeline
+
+**Outcome:** selected tracks can be turned into release-ready packages.
+
+- [ ] Metadata completeness rules
+- [ ] Lyrics editor/history
+- [ ] Artwork asset management
+- [ ] WAV/lossless export workflow
+- [ ] audio technical checks
+- [ ] description/tag generator as an explicit tool
+- [ ] release checklist
+- [ ] immutable asset-version history
+
+**Exit criteria**
+
+- one track has a clear `draft -> ready` preparation state
+- missing release fields are visible before publication
+- exports are reproducible and traceable to source assets
+
+## P4 — Publishing control plane
+
+**Outcome:** external publishing becomes safe, explicit, and auditable.
+
+- [ ] Define destination adapter interface
+- [ ] Implement prepare/validate step
+- [ ] Implement explicit approval gate
+- [ ] Persist `Release` and `DestinationPublication` state
+- [ ] Add idempotency keys for external writes where possible
+- [ ] Persist external IDs/URLs and execution evidence
+- [ ] Add retry policy for transient failures
+- [ ] Add first supported destination adapter
+
+**Exit criteria**
+
+- no external write occurs without an approved release
+- retries do not silently create duplicates
+- publication state can be reconstructed from local records
+
+## P5 — Operations and scale
+
+**Outcome:** high-volume use is observable and manageable.
+
+- [ ] queue/worker model for long-running jobs
+- [ ] structured logs and metrics
+- [ ] audit event viewer
+- [ ] storage lifecycle policy
+- [ ] backup/restore runbook
+- [ ] provider rate-limit controls
+- [ ] bulk metadata/preparation actions
+- [ ] library sync scheduler
+- [ ] operational dashboard
+
+## Product backlog after V1
+
+- multiple generation-provider adapters
+- local model adapter
+- stems and remix lineage
+- waveform/tempo/key analysis
+- artwork generation pipeline
+- release calendar
+- analytics ingestion
+- recommendation/selection assistant
+- automated metadata suggestions
+- mobile/remote control surface
+- plugin/extension API
+
+## Engineering rules
+
+1. No rewrite unless a measured constraint requires it.
+2. New provider code goes behind an adapter.
+3. Product state belongs to BlackMamba persistence.
+4. Long-running operations are jobs.
+5. External writes are explicit and auditable.
+6. Secrets remain server-side.
+7. Every milestone must ship a usable vertical slice.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,231 @@
+# Sunopo Architecture
+
+## Objective
+
+Evolve the current Next.js + Flask prototype into a stable control plane without throwing away working integration code.
+
+The main architectural change is to make provider-specific behavior live behind adapters while BlackMamba owns jobs, catalog identity, assets, release state, and audit history.
+
+## Current system
+
+```text
+Browser
+  |
+  v
+Next.js UI
+  |
+  +--> /display
+  +--> /control
+  |
+  v
+Next.js API proxy
+  |
+  v
+Flask backend
+  |
+  +--> SunoClient
+  +--> SessionStore / Redis
+  +--> media export
+  +--> catalog helpers
+  +--> storage
+```
+
+This split is acceptable for the next stage. A rewrite is not required.
+
+## Target boundaries
+
+```text
+                 +----------------------+
+                 |      Next.js UI      |
+                 +----------+-----------+
+                            |
+                            v
+                 +----------------------+
+                 |   Product API/BFF    |
+                 +----------+-----------+
+                            |
+        +-------------------+-------------------+
+        |                   |                   |
+        v                   v                   v
++---------------+   +---------------+   +---------------+
+| Generation    |   | Catalog       |   | Release       |
+| Service       |   | Service       |   | Service       |
++-------+-------+   +-------+-------+   +-------+-------+
+        |                   |                   |
+        v                   v                   v
++---------------+   +---------------+   +---------------+
+| Provider      |   | DB + Assets   |   | Destination   |
+| Adapters      |   |               |   | Adapters      |
++---------------+   +---------------+   +---------------+
+        |
+        +--> Suno adapter
+        +--> future providers
+```
+
+## Provider adapter contract
+
+Generation integrations should converge on a small internal interface rather than leaking provider SDK objects into product code.
+
+Conceptually:
+
+```python
+class GenerationProvider:
+    def create_job(self, request): ...
+    def get_job(self, provider_job_id): ...
+    def cancel_job(self, provider_job_id): ...
+    def list_library(self, cursor=None): ...
+    def fetch_asset(self, asset_ref): ...
+```
+
+The exact implementation may remain Python-first. The important constraint is that UI and catalog code consume normalized BlackMamba models.
+
+## Product API contracts
+
+Prefer versioned, resource-oriented contracts.
+
+Suggested surface:
+
+```text
+POST   /api/v1/generation-jobs
+GET    /api/v1/generation-jobs/:id
+POST   /api/v1/generation-jobs/:id/cancel
+
+GET    /api/v1/tracks
+POST   /api/v1/tracks
+GET    /api/v1/tracks/:id
+PATCH  /api/v1/tracks/:id
+
+GET    /api/v1/tracks/:id/variants
+GET    /api/v1/tracks/:id/assets
+POST   /api/v1/tracks/:id/exports
+
+POST   /api/v1/releases
+GET    /api/v1/releases/:id
+POST   /api/v1/releases/:id/approve
+POST   /api/v1/releases/:id/publish
+
+GET    /api/v1/system/health
+GET    /api/v1/audit-events
+```
+
+Existing endpoints can remain during migration and call the new services internally.
+
+## Persistence
+
+Redis is appropriate for transient session/job coordination, but the canonical catalog should use durable relational persistence.
+
+Recommended first durable model:
+
+- PostgreSQL for product state
+- object storage or filesystem abstraction for media assets
+- Redis for short-lived sessions, locks, queues, and cache
+
+Do not use provider APIs as the primary database.
+
+## Job model
+
+Generation should stop using UI-simulated progress as the source of truth.
+
+A job stores:
+
+- internal ID
+- provider
+- provider job ID
+- normalized request
+- status
+- attempts
+- timestamps
+- returned variant IDs
+- structured error
+
+The UI polls or subscribes to this product-owned state.
+
+## Asset model
+
+Store metadata separately from physical media.
+
+An asset record should capture:
+
+- asset ID
+- track/variant owner
+- kind (`audio`, `video`, `artwork`, `lyrics`, `waveform`, etc.)
+- MIME type
+- storage URI
+- checksum
+- byte size
+- source
+- created timestamp
+- derivation parent when transformed
+
+Checksums are important for duplicate detection and deterministic asset identity.
+
+## Authentication and sessions
+
+Production requirements:
+
+- no client-side shared secret as authorization
+- no provider credential exposed through `NEXT_PUBLIC_*`
+- authenticated server session for control surfaces
+- provider credentials stored server-side only
+- HttpOnly cookies where browser sessions are used
+- Secure cookies in HTTPS deployments
+- CSRF protection for browser-authenticated writes
+- explicit expiration/revocation
+
+The existing Redis/Fernet work is a useful foundation, but it needs to be connected to a real application-auth model.
+
+## External actions
+
+Publishing adapters should implement a two-phase product flow:
+
+1. **prepare/validate** — compute exactly what would be sent and return missing fields/warnings
+2. **execute** — run only after approval and persist result/evidence
+
+This makes automation safe and auditable.
+
+## Error contract
+
+Normalize errors at the product boundary.
+
+Example:
+
+```json
+{
+  "error": {
+    "code": "GENERATION_PROVIDER_UNAVAILABLE",
+    "message": "The generation provider could not be reached.",
+    "retryable": true,
+    "request_id": "req_..."
+  }
+}
+```
+
+Provider raw errors may be preserved in server logs but should not be exposed blindly to clients.
+
+## Observability
+
+Every request/job should have a correlation ID.
+
+Minimum signals:
+
+- structured application logs
+- generation job duration/success/failure
+- provider error rate
+- session failures
+- catalog sync counts
+- export failures
+- publication attempts/results
+- audit events for privileged actions
+
+## Migration strategy
+
+1. keep current UI and Flask runtime working
+2. fix current session/config defects
+3. add canonical models and service layer behind current endpoints
+4. migrate generation to durable jobs
+5. migrate library responses to canonical catalog
+6. add server-side auth for `/control`
+7. introduce versioned `/api/v1` contracts
+8. add publish adapters only after catalog identity is stable
+
+The core rule: evolve by vertical slice, not by rewrite.

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -1,0 +1,193 @@
+# Sunopo Product Contract
+
+## Product thesis
+
+Sunopo is the BlackMamba control plane for an end-to-end music workflow. It should let a creator move from an idea to a managed catalog item and eventually to an approved publication without depending on the UI or data model of any single generation provider.
+
+The product is built around a simple rule:
+
+> A generated clip is not the product. A managed, traceable music asset is the product.
+
+## Primary user
+
+The primary user is a high-volume creator who needs to generate, compare, organize, prepare, export, and publish many tracks while keeping metadata and source history intact.
+
+## Core jobs
+
+### 1. Generate
+
+Create one or more candidate tracks from a prompt, lyrics, style controls, and generation settings.
+
+Success means:
+
+- the request is represented as a durable job
+- returned variants are preserved
+- failures are actionable
+- the originating prompt/settings are retained
+
+### 2. Library
+
+Normalize generated tracks into a canonical BlackMamba catalog independent of the source provider.
+
+A catalog item should eventually own:
+
+- internal ID
+- provider/source IDs
+- title and version
+- artist and credits
+- lyrics
+- prompt and generation settings
+- audio/video/artwork assets
+- timestamps and status
+- publication state per destination
+- audit history
+
+### 3. Prepare
+
+Turn a selected candidate into a release-ready asset.
+
+Preparation can include:
+
+- metadata cleanup
+- lyrics
+- artwork
+- audio format variants
+- loudness/technical checks
+- descriptions and tags
+- duplicate/version detection
+- release checklist
+
+### 4. Publish
+
+Deliver an approved asset to supported external destinations.
+
+Publishing must be:
+
+- explicit
+- destination-aware
+- idempotent where possible
+- observable
+- auditable
+- reversible when the destination supports reversal
+
+No external write should be hidden behind a background side effect.
+
+## Product surfaces
+
+### Generate
+
+The creative cockpit. Prompt, lyrics, style, title, provider, job state, variants, playback, and selection.
+
+### Library
+
+The canonical catalog. Search, filters, versions, assets, metadata completeness, provider source, and publication status.
+
+### Track workspace
+
+One durable page per catalog item containing source history, lyrics, assets, metadata, analysis, exports, and release status.
+
+### Publish
+
+A release queue with destination readiness, missing-field checks, preview, explicit approval, execution result, and evidence.
+
+### Control
+
+Operational state: provider connectivity, queues, errors, sessions, storage, jobs, and audit events. This surface requires server-side authentication before production use.
+
+## Product principles
+
+1. **BlackMamba owns the canonical model.** Providers are adapters, not the database schema.
+2. **Jobs are durable.** Generation and publishing are represented as state machines, not fake progress bars.
+3. **Assets are immutable by default.** New transformations create versions rather than silently overwriting originals.
+4. **External actions are explicit.** Publishing and destructive operations require a clear user decision.
+5. **Everything important is traceable.** Source, prompt, version, transformation, publication, and error history remain inspectable.
+6. **Provider failures do not corrupt the catalog.** Local state remains coherent even when external systems fail.
+7. **Automation prepares; approval executes.** High-confidence automation can fill and validate data, but external writes remain governed.
+
+## Canonical entities
+
+### Track
+
+The creative identity of a song.
+
+### Variant
+
+A generated or edited version of a track.
+
+### Asset
+
+Audio, video, artwork, lyrics, stems, waveform, or other media attached to a track/variant.
+
+### GenerationJob
+
+A provider request and its lifecycle.
+
+Suggested states:
+
+`queued -> submitted -> processing -> complete | failed | cancelled`
+
+### Release
+
+A prepared publication package for one track/variant.
+
+### DestinationPublication
+
+The state of a release on one external platform.
+
+Suggested states:
+
+`draft -> ready -> approved -> publishing -> published | failed | withdrawn`
+
+### AuditEvent
+
+A durable record of a meaningful state transition or external action.
+
+## MVP definition
+
+Sunopo reaches MVP when one creator can reliably:
+
+1. authenticate to the local product
+2. connect a supported generation provider through server-managed credentials
+3. create a generation job
+4. receive and compare variants
+5. save a selected variant to the canonical library
+6. reopen that track later with all source metadata intact
+7. export a stable audio asset
+8. see clear failures and retry safely
+
+Publishing integrations are valuable but not required for the first product MVP; the catalog and generation workflow must be solid first.
+
+## V1 definition
+
+V1 adds the preparation and release workflow:
+
+- metadata completeness rules
+- artwork/lyrics/audio asset management
+- destination adapters
+- publication queue
+- explicit approval gate
+- audit trail and release evidence
+- operational dashboard
+
+## Non-goals for the first release
+
+- replacing a DAW
+- training a foundation audio model
+- pretending every provider has identical capabilities
+- fully autonomous publishing without approval
+- building analytics before catalog identity is reliable
+
+## Launch gates
+
+A production launch requires:
+
+- server-side authentication
+- secrets policy and secure session storage
+- provider adapter contract
+- persistent canonical catalog
+- job persistence
+- structured logs and audit events
+- test coverage for core state transitions
+- documented backup/recovery path
+- deployment runbook
+- terms/compliance review for each connected provider and destination


### PR DESCRIPTION
## What changed

This PR turns the repository from an outdated "Suno-like mock UI" description into an explicit pre-alpha product with a defined product contract, architecture, security gates, and executable roadmap.

### Product definition

- Reframes Sunopo as the **BlackMamba Music Control Plane** rather than a UI clone.
- Defines Generate, Library, Prepare, Publish, and Control as the core product surfaces.
- Establishes canonical BlackMamba entities: tracks, variants, assets, jobs, releases, destination publications, and audit events.
- Defines MVP and V1 boundaries plus non-goals.

### Architecture

- Documents the current Next.js -> Flask -> provider/session architecture.
- Defines a target provider-adapter boundary without requiring a rewrite.
- Proposes durable generation jobs and a canonical catalog independent of any one provider.
- Defines production requirements for server-side auth, secrets, error contracts, observability, and external write approval.

### Roadmap

Adds P0-P5 milestones with concrete exit criteria:

- P0 stabilize current runtime and security
- P1 durable generation jobs
- P2 canonical BlackMamba library
- P3 preparation pipeline
- P4 publishing control plane
- P5 operations and scale

### Configuration

- Updates `.env.example` to reflect the current backend, Redis/session, storage, and legacy control configuration.
- Removes the misleading idea that the current product is only a mock-generation interface.

## Why

The implementation has already moved beyond the old README: it contains real generation integration, library endpoints, Redis/Fernet session infrastructure, media export, and distribution experiments. The repository needed a product contract that matches the code and prevents future work from becoming disconnected features.

## Follow-up blockers created

- #15 Fix Flask session configuration initialization
- #16 Replace client-side control secret with server-side authentication
- #17 Introduce durable generation jobs and real progress state
- #18 Build canonical BlackMamba track library

## Validation

Compared `agent/productize-sunopo-v2` against `main`:

- 5 commits ahead
- 0 commits behind
- changes are documentation/configuration only
- no runtime source files changed in this PR

This is intentionally a foundation PR. The first runtime changes should land against the P0 issues above with focused tests.